### PR TITLE
fix the length bug

### DIFF
--- a/main.c
+++ b/main.c
@@ -15,8 +15,8 @@ int main (int argc, char *atgv[])
   {
     printf("\nEnter sentence %d: ", (i+1)); 
     fgets(string, sizeof(string), stdin); 
-    length= strlen(string)-1;  
-    printf("\nThe length of the sentence is: %d", length); 
+    length= strlen(string);  
+    printf("\nThe length of the sentence is: %d", length - 1); 
     ptr[i]= (char *) malloc(sizeof(char)*(length)); 
     strcpy(ptr, string); 
     hex_dump(ptr, length);  


### PR DESCRIPTION
strings in c are just char array with a null character at the end.

we need length + 1 to know the sentence length, also strcpy will try to copy the null character to the new memory location.

to do:
- this is not the only bug in the code, will leave bug/bugs to be discussed later.